### PR TITLE
feat: adiciona horários do Verão Beja 2025 para sábado e domingo

### DIFF
--- a/src/constants/trips/abaetetuba-beja.js
+++ b/src/constants/trips/abaetetuba-beja.js
@@ -302,10 +302,61 @@ export const bejaVerao2025 = {
         ]
       },
       {
+        origem: 'Abaetetuba',
+        destino: 'Beja',
+        periodo: 'Sábado (tarde/noite)',
+        obs: 'Das 13:00 às 23:00, a cada 30 minutos conforme a demanda, saída no Ter. Rodoviário',
+        horarios: [
+          {
+            hora: '13:00 às 23:00',
+            modalidade: 'Ter. Rodoviário'
+          }
+        ]
+      },
+      {
+        origem: 'Abaetetuba',
+        destino: 'Beja',
+        periodo: 'Domingo (manhã)',
+        horarios: [
+          {
+            hora: '06:00',
+            modalidade: 'Pç. da Bandeira'
+          },
+          {
+            hora: '06:30',
+            modalidade: 'Pç. da Bandeira'
+          },
+          {
+            hora: '07:00',
+            modalidade: 'Pç. da Bandeira'
+          },
+          {
+            hora: '07:30',
+            modalidade: 'Pç. da Bandeira'
+          }
+        ]
+      },
+      {
+        origem: 'Abaetetuba',
+        destino: 'Beja',
+        periodo: 'Domingo (integral)',
+        obs: 'Das 08:00 às 16:00, a cada 30 minutos conforme a demanda, saída no Ter. Rodoviário',
+        horarios: [
+          {
+            hora: '08:00 às 16:00',
+            modalidade: 'Ter. Rodoviário'
+          }
+        ]
+      },
+      {
         origem: 'Beja',
         destino: 'Abaetetuba',
         periodo: 'Sexta-feira',
         horarios: [
+          {
+            hora: '05:15',
+            modalidade: 'Beja'
+          },
           {
             hora: '06:00',
             modalidade: 'Beja'
@@ -407,6 +458,57 @@ export const bejaVerao2025 = {
           },
           {
             hora: '12:30',
+            modalidade: 'Beja'
+          }
+        ]
+      },
+      {
+        origem: 'Beja',
+        destino: 'Abaetetuba',
+        periodo: 'Sábado (tarde/noite)',
+        obs: 'A partir das 13:00, a cada 30 minutos conforme a demanda, saída em Beja',
+        horarios: [
+          {
+            hora: '13:00',
+            modalidade: 'Beja'
+          }
+        ]
+      },
+      {
+        origem: 'Beja',
+        destino: 'Abaetetuba',
+        periodo: 'Domingo (manhã)',
+        horarios: [
+          {
+            hora: '05:00',
+            modalidade: 'Beja'
+          },
+          {
+            hora: '05:30',
+            modalidade: 'Beja'
+          },
+          {
+            hora: '06:00',
+            modalidade: 'Beja'
+          },
+          {
+            hora: '06:30',
+            modalidade: 'Beja'
+          },
+          {
+            hora: '07:00',
+            modalidade: 'Beja'
+          }
+        ]
+      },
+      {
+        origem: 'Abaetetuba',
+        destino: 'Beja',
+        periodo: 'Domingo (integral)',
+        obs: 'A partir das 08:00, a cada 30 minutos conforme a demanda, saída em Beja',
+        horarios: [
+          {
+            hora: '08:00',
             modalidade: 'Beja'
           }
         ]

--- a/src/constants/trips/abaetetuba-beja.js
+++ b/src/constants/trips/abaetetuba-beja.js
@@ -502,8 +502,8 @@ export const bejaVerao2025 = {
         ]
       },
       {
-        origem: 'Abaetetuba',
-        destino: 'Beja',
+        origem: 'Beja',
+        destino: 'Abaetetuba',
         periodo: 'Domingo (integral)',
         obs: 'A partir das 08:00, a cada 30 minutos conforme a demanda, saída em Beja',
         horarios: [

--- a/src/pages/trips/components/BejaVerao2025.vue
+++ b/src/pages/trips/components/BejaVerao2025.vue
@@ -171,12 +171,11 @@
                   </q-item-section>
                 </q-item>
               </q-list>
-
-              <!-- Informações adicionais da rota -->
-              <div class="q-mb-sm text-center">
-                <q-badge color="primary" class="q-pa-xs text-weight-bold">
-                  💺 {{ getScheduleCount(viagem.horarios) }} horários disponíveis
-                </q-badge>
+              <div class="q-mb-sm text-center" v-if="viagem.obs">
+                <span class="text-subtitle2 text-grey-9 text-weight-bold">
+                  <q-icon name="mdi-alert" color="warning" size="sm" />
+                  {{ viagem.obs }}
+                </span>
               </div>
             </div>
           </q-card-section>

--- a/src/pages/trips/components/BejaVerao2025.vue
+++ b/src/pages/trips/components/BejaVerao2025.vue
@@ -173,7 +173,7 @@
               </q-list>
               <div class="q-mb-sm text-center" v-if="viagem.obs">
                 <span class="text-subtitle2 text-grey-9 text-weight-bold">
-                  <q-icon name="mdi-alert" color="warning" size="sm" />
+                  <q-icon name="mdi-alert" color="warning" size="sm" aria-label="Warning" />
                   {{ viagem.obs }}
                 </span>
               </div>


### PR DESCRIPTION
## 🎯 Contexto
Adição dos horários de ônibus para o Verão Beja 2025, incluindo novos horários para sábado e domingo, além de melhorias na exibição das informações.

## 📋 O que foi feito

### ✅ Backend/API
- N/A

### ✅ Provider/Estado  
- N/A

### ✅ UI/UX
- Adicionado campo de observações para horários com frequência variável
- Substituído contador de horários por informações mais relevantes sobre a frequência dos ônibus
- Melhorada a visualização das observações com ícone de alerta e formatação destacada

### ✅ Testes
- N/A

## 🔧 Detalhes técnicos

### Fluxo implementado
1. Adicionados novos horários para sábado (tarde/noite):
   - Abaetetuba → Beja: 13:00 às 23:00 (a cada 30 min)
   - Beja → Abaetetuba: a partir das 13:00 (a cada 30 min)

2. Adicionados horários para domingo:
   - Manhã (horários fixos):
     - Abaetetuba → Beja: 06:00, 06:30, 07:00, 07:30
     - Beja → Abaetetuba: 05:00, 05:30, 06:00, 06:30, 07:00
   
   - Período integral (frequência variável):
     - Abaetetuba → Beja: 08:00 às 16:00 (a cada 30 min)
     - Beja → Abaetetuba: a partir das 08:00 (a cada 30 min)

3. Adicionado horário extra na sexta-feira:
   - Beja → Abaetetuba: 05:15

## 🧪 Como testar
1. Acessar a página de horários do Verão Beja 2025
2. Verificar se os novos horários estão sendo exibidos corretamente
3. Confirmar se as observações sobre frequência variável estão sendo mostradas de forma clara
4. Validar se o ícone de alerta e a formatação das observações estão adequados