### PR TITLE
Atualização dos horários de viagem Abaetetuba-Belém

### DIFF
--- a/src/constants/trips/abaetetuba-belem.js
+++ b/src/constants/trips/abaetetuba-belem.js
@@ -316,9 +316,14 @@ export default {
               obs: 'Segunda a Sábado'
             },
             {
-              hora: '06:00*',
+              hora: '05:30',
               modalidade: 'Alça Viária',
-              obs: 'Domingos e Feriados (Pode sofrer alterações)'
+              obs: 'Segunda a Sábado'
+            },
+            {
+              hora: '06:00',
+              modalidade: 'Alça Viária',
+              obs: 'Domingos e Feriados'
             },
             {
               hora: '07:40',
@@ -347,7 +352,7 @@ export default {
             {
               hora: '13:45*',
               modalidade: 'Alça Viária',
-              obs: 'Pode sofrer alterações domingos e Feriados'
+              obs: 'Pode sofrer alterações no domingo e feriados'
             },
             {
               hora: '15:00',
@@ -373,9 +378,15 @@ export default {
           // periodo: 'Segunda a Sexta',
           horarios: [
             {
-              hora: '06:00*',
+              hora: '05:20',
               modalidade: 'Alça Viária',
-              obs: 'Domingos e Feriados (Pode sofrer alterações)'
+              obs: 'Segunda a Sábado'
+            },
+            {
+              hora: '06:20',
+              modalidade: 'Alça Viária',
+              obs: 'Domingos e Feriados'
+
             },
             {
               hora: '07:00',
@@ -399,8 +410,8 @@ export default {
             },
             {
               hora: '12:20',
-              modalidade: 'Alça Viária',
-              obs: 'A saída está ocorrendo 12:30 do terminal'
+              modalidade: 'Alça Viária'
+              // obs: 'A saída está ocorrendo 12:30 do terminal'
             },
             {
               hora: '13:30',
@@ -421,7 +432,7 @@ export default {
             {
               hora: '18:00*',
               modalidade: 'Alça Viária',
-              obs: 'Pode sofrer alterações domingos e Feriados'
+              obs: 'Pode sofrer alterações no domingo e Feriados'
             }
           ]
         }
@@ -438,7 +449,7 @@ export default {
           periodo: 'Segunda a Sexta',
           horarios: [
             {
-              hora: '02:00 | 03:30 | 04:20 | 05:30 | 06:15 | 07:00 | 07:45 | 08:30 | 09:15 | 10:00 | 11:00 | 12:00 | 13:00 | 14:00 | 15:00 |16:00 | 17:00 |18:00 | 19:00 | 20:00 | 21:30 | 23:00'
+              hora: '02:00 | 03:30 | 04:20 | 05:30 | 06:15 | 07:00 | 07:45 | 08:30 | 09:15 | 10:00 | 11:00 | 12:00 | 13:00 | 14:00 | 15:00 |16:00 | 17:00 | 18:00 | 19:00 | 20:00 | 21:30 | 23:00'
             }
           ]
         },
@@ -478,7 +489,7 @@ export default {
           periodo: 'Sábado',
           horarios: [
             {
-              hora: '02:00 | 04:00 | 06:00 | 07:00 | 08:00 | 09:00 | 10:00 | 11:00 | 12:00 | 13:00 | 14:00 | 15:00 | 16:00 | 17:00 | 18:00 | 20:00 | 22:00| 00:00'
+              hora: '02:00 | 04:00 | 06:00 | 07:00 | 08:00 | 09:00 | 10:00 | 11:00 | 12:00 | 13:00 | 14:00 | 15:00 | 16:00 | 17:00 | 18:00 | 20:00 | 22:00 | 00:00'
             }
           ]
         },
@@ -488,7 +499,7 @@ export default {
           periodo: 'Domingo',
           horarios: [
             {
-              hora: '04:00 | 06:00 | 07:00 | 08:00 | 09:00 | 10:00 | 11:00 | 12:00 | 13:00 | 14:00 | 15:00 | 16:00 | 17:00 | 18:00 | 19:00 | 20:00 | 21:30| 23:00'
+              hora: '04:00 | 06:00 | 07:00 | 08:00 | 09:00 | 10:00 | 11:00 | 12:00 | 13:00 | 14:00 | 15:00 | 16:00 | 17:00 | 18:00 | 19:00 | 20:00 | 21:30 | 23:00'
             }
           ]
         }


### PR DESCRIPTION
## 🎯 Contexto
Atualização dos horários de viagem entre Abaetetuba e Belém para refletir as mudanças nos horários reais dos ônibus, incluindo novos horários e ajustes nas observações dos horários existentes.

## 📋 O que foi feito

### ✅ Backend/API
- 

### ✅ Provider/Estado  
- 

### ✅ UI/UX
- Atualização dos horários de viagem no arquivo de constantes `abaetetuba-belem.js`
- Ajuste nas observações dos horários para maior clareza
- Correção de formatação nos horários (espaçamento)

### ✅ Testes
- 

## 🔧 Detalhes técnicos

### Fluxo implementado
1. Adicionado novo horário 05:30 (Alça Viária) para segunda a sábado
2. Ajustado horário 06:00 para domingos e feriados (removido asterisco)
3. Adicionado horário 05:20 (Alça Viária) para segunda a sábado no sentido contrário
4. Adicionado horário 06:20 (Alça Viária) para domingos e feriados
5. Removida observação específica do horário 12:20 que estava desatualizada
6. Padronização das observações de horários especiais
7. Correção de formatação nos horários com múltiplas opções

## 🧪 Como testar
1. Acesse a seção de horários de viagem no app
2. Verifique os horários de Abaetetuba para Belém
3. Verifique os horários de Belém para Abaetetuba
4. Confirme se as observações estão claras e atualizadas
5. Teste em diferentes dias da semana para validar os horários corretos